### PR TITLE
added code for drivetrain encoders

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -56,6 +56,30 @@ public final class Constants {
 
     public static final boolean LEFT_ENCODERS_REVERSE = false;
     public static final boolean RIGHT_ENCODERS_REVERSE = true;
+
+    // https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages/blob/master/Java/VelocityClosedLoop/src/main/java/frc/robot/Constants.java
+    /**
+     * Which PID slot to pull gains from. Starting 2018, you can choose from
+     * 0,1,2 or 3. Only the first two (0,1) are visible in web-based
+     * configuration.
+     */
+    public static final int kSlotIdx = 0;
+    /**
+     * Talon SRX/ Victor SPX will supported multiple (cascaded) PID loops. For
+     * now we just want the primary one.
+     */
+    public static final int kPIDLoopIdx = 0;
+    /**
+     * Set to zero to skip waiting for confirmation, set to nonzero to wait and
+     * report to DS if action fails.
+     */
+    public static final int kTimeoutMs = 30;
+    /**
+     * PID Gains may have to be adjusted based on the responsiveness of control loop.
+     * kF: 1023 represents output value to Talon at 100%, 7200 represents Velocity units at 100% output
+     * 
+     * 	                                    			  kP   kI   kD   kF          Iz    PeakOut */
+    public final static Gains kGains_Velocit = new Gains( 0.25, 0.001, 20, 1023.0/7200.0,  300,  1.00);
     
     // math garbage
     public static final double ENCODER_COUNT_PER_ROTATION = 360; // number of pulses per full rotation 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -25,10 +25,10 @@ public final class Constants {
 		public static final int PISTONIN = 0; // piston for wof deployment 
     public static final int PISTONOUT = 1;
 
-    public static final Color RED = new Color(0.5, 0.3, 0);
+    public static final Color RED = new Color(1, 0, 0);
     public static final Color GREEN = new Color(0, 1, 0);
     public static final Color BLUE = new Color(0, 0, 1);
-    public static final Color YELLOW = new Color(0.3, 0.5, 0);
+    public static final Color YELLOW = new Color(0.5, 0.5, 0);
 
     public static final Color[] wheelColors ={ // the colors on the WOF in order 
       RED, // red
@@ -124,24 +124,34 @@ public final class Constants {
     }
     public static final class ConveyerConstants{
 
-      public static final int INTAKE_LEFT = 3;
-      public static final int INTAKE_RIGHT = 3;
+      public static final int INTAKE_LEFT = 5;
+      public static final int INTAKE_RIGHT = 5;
       
-      public static final int CLIP_LEFT = 3;
-      public static final int CLIP_RIGHT = 3;
+      public static final int CLIP_LEFT = 6;
+      public static final int CLIP_RIGHT = 6;
       
-      public static final int DUMP_LEFT = 3;
-      public static final int DUMP_RIGHT = 3;
+      public static final int DUMP_LEFT = 7;
+      public static final int DUMP_RIGHT = 7;
 
     }
 
     public static final class ClimbConstants{
 
-		public static final int LEFT_TELESCOPE = 0; // left telescope motor
-    public static final int RIGHT_TELESCOPE = 0; // right telescope motor
+		public static final int LEFT_TELESCOPE = 8; // left telescope motor
+    public static final int RIGHT_TELESCOPE = 9; // right telescope motor
     
-		public static final int WINCH_1 = 0; // motor for the winch
-		public static final int WINCH_2 = 0; // 2nd winch motor
+		public static final int WINCH_1 = 10; // motor for the winch
+		public static final int WINCH_2 = 11; // 2nd winch motor
 
+    }
+
+    public static final class RGBConstants{
+
+      // color components for the super cool rgb lights
+		public static final int RED_LED = 0;
+		public static final int BLUE_LED = 1;
+		public static final int GREEN_LED = 2;
+
+      
     }
 }

--- a/src/main/java/frc/robot/Gains.java
+++ b/src/main/java/frc/robot/Gains.java
@@ -1,0 +1,23 @@
+// https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages/blob/master/Java/VelocityClosedLoop/src/main/java/frc/robot/Gains.java
+/**
+ *  Class that organizes gains used when assigning values to slots
+ */
+package frc.robot;
+
+public class Gains {
+	public final double kP;
+	public final double kI;
+	public final double kD;
+	public final double kF;
+	public final int kIzone;
+	public final double kPeakOutput;
+	
+	public Gains(double _kP, double _kI, double _kD, double _kF, int _kIzone, double _kPeakOutput){
+		kP = _kP;
+		kI = _kI;
+		kD = _kD;
+		kF = _kF;
+		kIzone = _kIzone;
+		kPeakOutput = _kPeakOutput;
+	}
+}

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -16,12 +16,14 @@ import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 
 import frc.robot.commands.ExampleCommand;
 import frc.robot.commands.conveyer_commands.*;
+import frc.robot.commands.rgb_xd.WOF_ColorSync;
 import frc.robot.commands.wheel_of_fortune.*;
 import frc.robot.commands.climb_commands.*;
 
 import frc.robot.subsystems.BallConveyer;
 import frc.robot.subsystems.Climb;
 import frc.robot.subsystems.ExampleSubsystem;
+import frc.robot.subsystems.RGBWOOOOOOYEAHHH;
 import frc.robot.subsystems.WheelOfFortune;
 
 /**
@@ -39,6 +41,7 @@ public class RobotContainer {
   private final WheelOfFortune m_WheelOfFortune = new WheelOfFortune();
   private final BallConveyer m_BallConveyer = new BallConveyer();
   private final Climb m_Climb = new Climb();
+  private final RGBWOOOOOOYEAHHH m_rgb = new RGBWOOOOOOYEAHHH();
 
 
   SendableChooser<Command> m_chooser = new SendableChooser<>(); // allows the drivers to choose auto mode in driver station.
@@ -94,6 +97,11 @@ public class RobotContainer {
         .whenPressed(new SpinWOF(m_WheelOfFortune));
       new JoystickButton(operator, Constants.OIConstants.HOLD_WOF) // hold on color
         .whenPressed(new WOFHoldOnColor(m_WheelOfFortune));
+
+      new JoystickButton(operator, Constants.OIConstants.SPIN_WOF) // sync LEDs with color sensor (same button as spin 3 times)
+        .whenPressed(new WOF_ColorSync(m_rgb, m_WheelOfFortune));
+      new JoystickButton(operator, Constants.OIConstants.HOLD_WOF) // sync LEDs with color sensor (same button as hold wof)
+        .whenPressed(new WOF_ColorSync(m_rgb, m_WheelOfFortune));
   }
 
 

--- a/src/main/java/frc/robot/commands/rgb_xd/WOF_ColorSync.java
+++ b/src/main/java/frc/robot/commands/rgb_xd/WOF_ColorSync.java
@@ -1,0 +1,51 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands.rgb_xd;
+
+import edu.wpi.first.wpilibj.util.Color;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.RGBWOOOOOOYEAHHH;
+import frc.robot.subsystems.WheelOfFortune;
+
+public class WOF_ColorSync extends CommandBase {
+  private Color m_sensorColor;
+  private RGBWOOOOOOYEAHHH m_rgb;
+  private WheelOfFortune m_wof;
+  /**
+   * Creates a new WOF_ColorSync.
+   */
+  public WOF_ColorSync(RGBWOOOOOOYEAHHH rgbsub, WheelOfFortune wofsub) {
+    // Use addRequirements() here to declare subsystem dependencies.
+    m_wof = wofsub;
+    m_rgb = rgbsub;
+    addRequirements(m_rgb);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    m_sensorColor = m_wof.colorSensor.getColor();
+    m_rgb.SetRGBColor(m_sensorColor.red, m_sensorColor.green, m_sensorColor.blue);  
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/wheel_of_fortune/SpinWOF.java
+++ b/src/main/java/frc/robot/commands/wheel_of_fortune/SpinWOF.java
@@ -31,7 +31,7 @@ public class SpinWOF extends CommandBase {
   }
 
   public void colorChange(){// count the number of times we switch TO yellow.
-    Color blue = Constants.WOFConstants.BLUE; // 
+    Color blue = Constants.WOFConstants.BLUE; // it's all a lie, it's not blue at all
 
     m_dash.putNumber("aprob red", sensorColor.red);
     m_dash.putNumber("aprob green", sensorColor.green);

--- a/src/main/java/frc/robot/commands/wheel_of_fortune/WOFHelpers.java
+++ b/src/main/java/frc/robot/commands/wheel_of_fortune/WOFHelpers.java
@@ -15,11 +15,39 @@ public class WOFHelpers {
 
     public static double aproximateColor(Color color1, Color color2){ // just returns the euclidean distance between a given color and the sensor's color
 
-    // we multiply the diff in red so that we can tell similar RGBs like red and yellow apart
-    double distS1 = (Math.pow( color1.red - color2.red,2)*10)+Math.pow( color1.blue - color2.blue,2)+Math.pow( color1.green - color2.green,2);
-    double distS2 = Math.sqrt(distS1);
 
-    return distS2;
+    // multiply the diff in red so that we can tell similar RGBs like red and yellow apart
+    double distS1red = (Math.pow( color1.red - color2.red,2)*10)+Math.pow( color1.blue - color2.blue,2)+Math.pow( color1.green - color2.green,2);
+    double distred = Math.sqrt(distS1red);
+
+    // multiply the diff in red so that we can tell similar RGBs like red and yellow apart
+    double distS1blue = (Math.pow( color1.red - color2.red,2)*10)+Math.pow( color1.blue - color2.blue,2)+Math.pow( color1.green - color2.green,2);
+    double distblue = Math.sqrt(distS1blue);
+
+    // multiply the diff in red so that we can tell similar RGBs like red and yellow apart
+    double distS1green = (Math.pow( color1.red - color2.red,2)*10)+Math.pow( color1.blue - color2.blue,2)+Math.pow( color1.green - color2.green,2);
+    double distgreen = Math.sqrt(distS1green);
+
+    // multiply the diff in red so that we can tell similar RGBs like red and yellow apart
+    double distS1yellow = (Math.pow( color1.red - color2.red,2)*10)+Math.pow( color1.blue - color2.blue,2)+Math.pow( color1.green - color2.green,2);
+    double distyellow = Math.sqrt(distS1yellow);
+
+    // find the lowest diff 
+    double lowestS1 = Math.min(distred, distblue);
+    double lowestS2 = Math.min(distgreen, distyellow);
+    double lowest = Math.min(lowestS1, lowestS2);
+
+    if(distred == lowest){
+
+    }else if(distblue == lowest){
+
+    }else if(distgreen == lowest){
+
+    }else if(distyellow == lowest){
+
+    }
+
+    return 5;
   }
 
 }

--- a/src/main/java/frc/robot/subsystems/Climb.java
+++ b/src/main/java/frc/robot/subsystems/Climb.java
@@ -14,16 +14,21 @@ import edu.wpi.first.wpilibj.Victor;
 
 public class Climb extends SubsystemBase {
   // motors for extending telescopes
-  private final Victor leftTelescopeMotor = new Victor(ClimbConstants.LEFT_TELESCOPE);
-  private final Victor rightTelescopeMotor = new Victor(ClimbConstants.RIGHT_TELESCOPE);
+  public Victor leftTelescopeMotor;
+  public Victor rightTelescopeMotor;
 
   // motors that are part of the winch
-  private final Victor winchVictor1 = new Victor(ClimbConstants.WINCH_1);
-  private final Victor winchVictor2 = new Victor(ClimbConstants.WINCH_2);
+  public Victor winchVictor1;
+  public Victor winchVictor2;
 
 
   public Climb() {
     // if required configure the brakemode for the winch here
+    leftTelescopeMotor = new Victor(ClimbConstants.LEFT_TELESCOPE);
+    rightTelescopeMotor = new Victor(ClimbConstants.RIGHT_TELESCOPE);
+
+    winchVictor1 = new Victor(ClimbConstants.WINCH_1);
+    winchVictor2 = new Victor(ClimbConstants.WINCH_2);
 
   }
 

--- a/src/main/java/frc/robot/subsystems/DriveTrain.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrain.java
@@ -51,6 +51,7 @@ public class DriveTrain extends SubsystemBase {
    */
   public DriveTrain() {
     // m_stick = m_RobotContainer.driver;
+    SetUpEncoders();
   }
   //https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages/blob/master/Java/VelocityClosedLoop/src/main/java/frc/robot/Robot.java 
   private void SetUpEncoders(){

--- a/src/main/java/frc/robot/subsystems/DriveTrain.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrain.java
@@ -12,6 +12,7 @@ import frc.robot.commands.drive_commands.DefaultDrive;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants;
 import frc.robot.RobotContainer;
 import frc.robot.Constants.DriveConstants;
 
@@ -51,7 +52,63 @@ public class DriveTrain extends SubsystemBase {
   public DriveTrain() {
     // m_stick = m_RobotContainer.driver;
   }
-	 
+  //https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages/blob/master/Java/VelocityClosedLoop/src/main/java/frc/robot/Robot.java 
+  private void SetUpEncoders(){
+    /* Factory Default all hardware to prevent unexpected behaviour */
+    frontLeftMotor.configFactoryDefault();
+
+    /* Config sensor used for Primary PID [Velocity] */
+    frontLeftMotor.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative,
+                                                Constants.DriveConstants.kPIDLoopIdx, 
+                                                Constants.DriveConstants.kTimeoutMs);
+
+    /**
+    * Phase sensor accordingly. 
+    * Positive Sensor Reading should match Green (blinking) Leds on Talon
+    */
+    frontLeftMotor.setSensorPhase(true);
+
+    /* Config the peak and nominal outputs */
+    frontLeftMotor.configNominalOutputForward(0, Constants.DriveConstants.kTimeoutMs);
+    frontLeftMotor.configNominalOutputReverse(0, Constants.DriveConstants.kTimeoutMs);
+    frontLeftMotor.configPeakOutputForward(1, Constants.DriveConstants.kTimeoutMs);
+    frontLeftMotor.configPeakOutputReverse(-1, Constants.DriveConstants.kTimeoutMs);
+
+    /* Config the Velocity closed loop gains in slot0 */
+    frontLeftMotor.config_kF(Constants.DriveConstants.kPIDLoopIdx, Constants.DriveConstants.kGains_Velocit.kF, Constants.DriveConstants.kTimeoutMs);
+    frontLeftMotor.config_kP(Constants.DriveConstants.kPIDLoopIdx, Constants.DriveConstants.kGains_Velocit.kP, Constants.DriveConstants.kTimeoutMs);
+    frontLeftMotor.config_kI(Constants.DriveConstants.kPIDLoopIdx, Constants.DriveConstants.kGains_Velocit.kI, Constants.DriveConstants.kTimeoutMs);
+    frontLeftMotor.config_kD(Constants.DriveConstants.kPIDLoopIdx, Constants.DriveConstants.kGains_Velocit.kD, Constants.DriveConstants.kTimeoutMs);
+
+
+
+    /* Factory Default all hardware to prevent unexpected behaviour */
+    frontRightMotor.configFactoryDefault();
+
+    /* Config sensor used for Primary PID [Velocity] */
+    frontRightMotor.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative,
+                                                  Constants.DriveConstants.kPIDLoopIdx, 
+                                                  Constants.DriveConstants.kTimeoutMs);
+
+    /**
+     * Phase sensor accordingly. 
+     * Positive Sensor Reading should match Green (blinking) Leds on Talon
+     */
+    frontRightMotor.setSensorPhase(true);
+
+    /* Config the peak and nominal outputs */
+    frontRightMotor.configNominalOutputForward(0, Constants.DriveConstants.kTimeoutMs);
+    frontRightMotor.configNominalOutputReverse(0, Constants.DriveConstants.kTimeoutMs);
+    frontRightMotor.configPeakOutputForward(1, Constants.DriveConstants.kTimeoutMs);
+    frontRightMotor.configPeakOutputReverse(-1, Constants.DriveConstants.kTimeoutMs);
+
+    /* Config the Velocity closed loop gains in slot0 */
+    frontRightMotor.config_kF(Constants.DriveConstants.kPIDLoopIdx, Constants.DriveConstants.kGains_Velocit.kF, Constants.DriveConstants.kTimeoutMs);
+    frontRightMotor.config_kP(Constants.DriveConstants.kPIDLoopIdx, Constants.DriveConstants.kGains_Velocit.kP, Constants.DriveConstants.kTimeoutMs);
+    frontRightMotor.config_kI(Constants.DriveConstants.kPIDLoopIdx, Constants.DriveConstants.kGains_Velocit.kI, Constants.DriveConstants.kTimeoutMs);
+    frontRightMotor.config_kD(Constants.DriveConstants.kPIDLoopIdx, Constants.DriveConstants.kGains_Velocit.kD, Constants.DriveConstants.kTimeoutMs);
+  }
+
   // USS reads between 25cm - 765cm   
   // https://www.andymark.com/products/ultrasonic-proximity-sensor-ez-mb1013-maxbotix
   public double GetDistance() {
@@ -109,6 +166,7 @@ public class DriveTrain extends SubsystemBase {
   @Override
   public void periodic() {
     // This method will be called once per scheduler run
+    System.out.println(frontLeftMotor.getSelectedSensorVelocity(Constants.DriveConstants.kPIDLoopIdx));
   }
 
 }

--- a/src/main/java/frc/robot/subsystems/RGBWOOOOOOYEAHHH.java
+++ b/src/main/java/frc/robot/subsystems/RGBWOOOOOOYEAHHH.java
@@ -1,0 +1,58 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.subsystems;
+
+import edu.wpi.first.wpilibj.PWM;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+import frc.robot.Constants.RGBConstants;
+
+public class RGBWOOOOOOYEAHHH extends SubsystemBase {
+
+  public PWM redLED;
+  public PWM blueLED;
+  public PWM greenLED;
+
+  /**
+   * Creates a new RGBWOOOOOOYEAHHH.
+   */
+  public RGBWOOOOOOYEAHHH() {
+    redLED = new PWM(RGBConstants.RED_LED);
+    blueLED = new PWM(RGBConstants.BLUE_LED);
+    greenLED = new PWM(RGBConstants.GREEN_LED);
+
+  }
+
+  // private double IntToPWN(int input){
+  //   if(input > 255){ input = 255;}
+  //   if(input < 0){ input = 0;}
+    
+  //   return input/255;
+  // }
+
+  /**
+   * 
+   * sets the rgb lights to a given red green blue values
+   * 
+   * @param red   red component 0-1
+   * @param green  blue component 0-1
+   * @param blue  green component 0-1
+   */
+
+  public void SetRGBColor(Double red, Double green, Double blue){
+    redLED.setPosition(red);
+    greenLED.setPosition(green);
+    blueLED.setPosition(blue);
+
+  }
+
+  @Override
+  public void periodic() {
+    // This method will be called once per scheduler run
+  }
+}


### PR DESCRIPTION
These changes still need to be tested on the protobot. Example code that we worked from can be found [here](https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages/tree/master/Java/VelocityClosedLoop). We were not able to put this code on the protobot on Tuesday because there was an issue with initializing the Climb subsystem. It appears that we are trying to initialize two Victors with the same id. See constants to see that both left and right ids are set to `0`

Andymark has a different set of example code that can be found [on this page](https://www.andymark.com/products/srx-magnetic-encoder) that appears to be much simpler and may be easier to implement than the other example.